### PR TITLE
Auto Format using google-libphonenumber

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -70,6 +70,12 @@ declare module "react-phone-input-2" {
     disabled?: boolean;
 
     autoFormat?: boolean;
+    /**
+     * Format using google-libphonenumberjs library
+     * instead of the default autoFormat.
+     * NOTE: Make sure to turn autoFormat false
+     * */
+    googleAutoFormat?: boolean;
     enableAreaCodes?: boolean;
     enableTerritories?: boolean;
 

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.6",
+    "google-libphonenumber": "^3.2.30",
     "lodash.debounce": "^4.0.8",
     "lodash.memoize": "^4.1.2",
     "lodash.reduce": "^4.6.0",

--- a/src/PhoneNumber.js
+++ b/src/PhoneNumber.js
@@ -1,0 +1,24 @@
+import libPhoneNumber from "google-libphonenumber";
+
+const asYouTypeFormatter = libPhoneNumber.AsYouTypeFormatter;
+
+class PhoneNumber {
+    // eslint-disable-next-line class-methods-use-this
+    format(number, iso2) {
+        const formatter = new asYouTypeFormatter(iso2); // eslint-disable-line new-cap
+        let formatted;
+
+        number.replace(/-/g, "")
+            .replace(/ /g, "")
+            .replace(/\(/g, "")
+            .replace(/\)/g, "")
+            .split("")
+            .forEach((n) => {
+                formatted = formatter.inputDigit(n);
+            });
+
+        return formatted;
+    }
+}
+
+export default new PhoneNumber();

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import classNames from 'classnames';
 import './utils/prototypes'
 
 import CountryData from './CountryData.js';
+import PhoneNumber from "./PhoneNumber";
 
 class PhoneInput extends React.Component {
   static propTypes = {
@@ -41,6 +42,7 @@ class PhoneInput extends React.Component {
     className: PropTypes.string,
 
     autoFormat: PropTypes.bool,
+    googleAutoFormat: PropTypes.bool,
 
     enableAreaCodes: PropTypes.oneOfType([
       PropTypes.bool,
@@ -130,6 +132,7 @@ class PhoneInput extends React.Component {
     className: '',
 
     autoFormat: true,
+    googleAutoFormat: false,
     enableAreaCodes: false,
     enableTerritories: false,
     disableCountryCode: false,
@@ -401,8 +404,8 @@ class PhoneInput extends React.Component {
   formatNumber = (text, country) => {
     if (!country) return text;
 
-    const { format } = country;
-    const { disableCountryCode, enableAreaCodeStretch, enableLongNumbers, autoFormat } = this.props;
+    const { format, iso2 } = country;
+    const { disableCountryCode, enableAreaCodeStretch, enableLongNumbers, autoFormat, googleAutoFormat } = this.props;
 
     let pattern;
     if (disableCountryCode) {
@@ -421,6 +424,13 @@ class PhoneInput extends React.Component {
 
     if (!text || text.length === 0) {
       return disableCountryCode ? '' : this.props.prefix;
+    }
+
+    /**
+     * Handled using google-libphonenumberjs library
+     * */
+    if (googleAutoFormat) {
+      return disableCountryCode ? text : PhoneNumber.format(this.props.prefix+text, iso2);
     }
 
     // for all strings with length less than 3, just return it (1, 2 etc.)


### PR DESCRIPTION
In our react-native app the formatting of some countries were not matching the formatting which this library was providing. In the library used in react-native app formatting is done using google-libphonenumber. So to match the formatting for web same as react-native app we added optional formatting using the google-libphonenumber. 
Added a new prop named `googleAutoFormat` which will format using google-libphonenumber. 
Custom masking will not work while using `googleAutoFormat`.

The react-native library [here](https://github.com/rili-live/react-native-phone-input).